### PR TITLE
Wrapping feature name in CDATA tag.

### DIFF
--- a/libKML/features/Feature.php
+++ b/libKML/features/Feature.php
@@ -69,7 +69,7 @@ abstract class Feature extends KMLObject {
     $output = array();
     
     if (isset($this->name)) {
-      $output[] = sprintf("\t<name>%s</name>", htmlentities($this->name));
+      $output[] = sprintf("\t<name><![CDATA[ %s ]]></name>", $this->name);
     }
     
     if (isset($this->visibility)) {


### PR DESCRIPTION
Ampersands in Placename names result in "not well-formed (invalid token)" errors in Google Earth if they aren't wrapped in CDATA.  htmlentities creates lots of ampersands, so names with single or double quotes choke too with htmlentities.

With CDATA names like "Bob & Sam & William’s Cabin" get through fine.
